### PR TITLE
Fix nullable encoder typo

### DIFF
--- a/src/Data/JsonSpec/Elm.hs
+++ b/src/Data/JsonSpec/Elm.hs
@@ -276,7 +276,7 @@ instance (HasType spec) => HasType (JsonNullable spec) where
       Expr.Lam . toScope $
         Expr.apps
           "Maybe.withDefault"
-          [ "Json.Decode.null"
+          [ "Json.Encode.null"
           , Expr.apps
               "Maybe.map"
               [ Expr.bind Expr.Global absurd encoder


### PR DESCRIPTION
Hey, was trying this out in a side project, and noticed that the generated encoder for nullable types uses `Json.Decode.null` instead of `Json.Encode.null` (seems like a simple typo?)
https://github.com/pete-murphy/oru/blob/86deca4291793d8aace540693e517adf34910d14/frontend/src/Api/Data.elm#L32