### PR TITLE
Add JsonDict Elm codegen support

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,30 +14,79 @@ jobs:
           - '9.14'
         cabal-version: ['3.16.1.0']
     steps:
-      # Checkout
-      - uses: actions/checkout@v3
-        
-      # Setup
+      - uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # TEMPORARY HACKAGE BOOTSTRAP WORKAROUND
+      # ------------------------------------------------------------------
+      # Cause: 2026 root key signing ceremony deployed root.json v8.
+      # cabal 3.16.1.0's baked-in bootstrap keys predate that ceremony, so
+      # a fresh `cabal update` fails TUF checks (then falls through to the
+      # dead dream.io mirror and looks like a 404).
+      #
+      # root-keys below are copied from cabal master's
+      # defaultHackageRemoteRepoKeys (threshold remains 3). Verify them
+      # yourself before trusting this workflow:
+      #
+      #   Cabal master bootstrap keys:
+      #   https://github.com/haskell/cabal/blob/4907eec7b275aa0e1a31333fc745b3cc9f023f4f/cabal-install/src/Distribution/Client/Config.hs#L911-L939
+      #
+      #   Ceremony root.json (roles.root.keyids):
+      #   https://github.com/haskell-infra/hackage-root-keys/blob/d308c26d892ed20d906c4e9435aa70ac9980a872/root.json
+      #
+      #   Ceremony PR:
+      #   https://github.com/haskell-infra/hackage-root-keys/pull/27
+      #
+      # TO REVERT (when a stock `cabal update` works with no custom
+      # root-keys — e.g. a cabal release ships the updated keys):
+      #   1. Delete this entire step in both jobs.
+      #   2. On each "Setup Haskell" step, remove `cabal-update: false`
+      #      (or set it to `true`) and delete the following
+      #      "Cabal update" step.
+      #   Leave all other CI changes in this file alone.
+      # ------------------------------------------------------------------
+      - name: Bootstrap Hackage trust anchors
+        run: |
+          rm -rf ~/.cabal/packages ~/.cache/cabal/packages
+          # Cabal 3.12 uses ~/.cabal; 3.14+ prefers XDG ~/.config/cabal.
+          mkdir -p ~/.cabal ~/.config/cabal
+          tee ~/.cabal/config ~/.config/cabal/config > /dev/null <<'EOF'
+          repository hackage.haskell.org
+            url: https://hackage.haskell.org/
+            secure: True
+            root-keys:
+              fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+              1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+              0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+              51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+              d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522
+              c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93
+            key-threshold: 3
+          EOF
+
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
         id: setup
-        if: steps.tooling-cache.outputs.cache-hit != 'true'
         with:
           ghc-version: ${{ matrix.ghc-version }}
           cabal-version: ${{ matrix.cabal-version }}
+          # Pair with the bootstrap workaround above. Revert notes are
+          # on that step.
+          cabal-update: false
 
-      # Generate Plan
+      - name: Cabal update
+        run: cabal update
+
       - name: Configure the Build
         run: |
-          rm cabal.project.freeze
+          rm -f cabal.project.freeze
           # We can't run tests in this project because testing requires
           # Elm to be installed.
           cabal configure
           cabal build --dry-run
 
-      # Restore cache
       - name: Restore cached dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: cache
         env:
           key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
@@ -45,20 +94,17 @@ jobs:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
 
-      # Build deps (for caching)
       - name: Cabal build dependencies
         run: cabal build all --only-dependencies
 
-      # Save dependency cache
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
-      # Cabal build
-      - name: Cabal Bulid
+      - name: Cabal Build
         run: |
           cabal build all
 
@@ -71,19 +117,54 @@ jobs:
         ghc-version: ['9.8.4']
         cabal-version: ['3.8.1.0']
     steps:
-      # Checkout
-      - uses: actions/checkout@v3
-        
-      # Setup
+      - uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # TEMPORARY HACKAGE BOOTSTRAP WORKAROUND
+      # ------------------------------------------------------------------
+      # See the matching step in the "build" job for full context and
+      # verification links for the root-keys list.
+      #
+      # TO REVERT (when a stock `cabal update` works with no custom
+      # root-keys — e.g. a cabal release ships the updated keys):
+      #   1. Delete this entire step in both jobs.
+      #   2. On each "Setup Haskell" step, remove `cabal-update: false`
+      #      (or set it to `true`) and delete the following
+      #      "Cabal update" step.
+      #   Leave all other CI changes in this file alone.
+      # ------------------------------------------------------------------
+      - name: Bootstrap Hackage trust anchors
+        run: |
+          rm -rf ~/.cabal/packages ~/.cache/cabal/packages
+          # Cabal 3.12 uses ~/.cabal; 3.14+ prefers XDG ~/.config/cabal.
+          mkdir -p ~/.cabal ~/.config/cabal
+          tee ~/.cabal/config ~/.config/cabal/config > /dev/null <<'EOF'
+          repository hackage.haskell.org
+            url: https://hackage.haskell.org/
+            secure: True
+            root-keys:
+              fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+              1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+              0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+              51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+              d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522
+              c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93
+            key-threshold: 3
+          EOF
+
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
         id: setup
-        if: steps.tooling-cache.outputs.cache-hit != 'true'
         with:
           ghc-version: ${{ matrix.ghc-version }}
           cabal-version: ${{ matrix.cabal-version }}
+          # Pair with the bootstrap workaround above. Revert notes are
+          # on that step.
+          cabal-update: false
 
-      # Generate Plan
+      - name: Cabal update
+        run: cabal update
+
       - name: Configure the Build
         run: |
           (cat << EOF
@@ -103,15 +184,14 @@ jobs:
             unordered-containers == 0.2.19.1
           EOF
           ) > cabal.project
-          rm cabal.project.freeze
+          rm -f cabal.project.freeze
           # We can't run tests in this project because testing requires
           # Elm to be installed.
           cabal configure
           cabal build --dry-run
 
-      # Restore cache
       - name: Restore cached dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: cache
         env:
           key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
@@ -119,19 +199,15 @@ jobs:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
 
-      # Build deps (for caching)
       - name: Cabal build dependencies
         run: cabal build all --only-dependencies
 
-      # Save dependency cache
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
-      # Cabal Build
-      - name: Cabal Bulid
+      - name: Cabal Build
         run: cabal build all
-

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -176,7 +176,7 @@ jobs:
             directory == 1.3.7.1,
             elm-syntax == 0.3.3.0,
             hspec == 2.11.1,
-            json-spec == 1.3.0.0,
+            json-spec == 1.4.0.0,
             mtl == 2.3.1,
             prettyprinter == 1.7.1,
             process == 1.6.25.0,

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -62,7 +62,7 @@ constraints: any.HUnit ==1.6.2.0,
              any.integer-conversion ==0.1.1,
              any.integer-logarithms ==1.0.5,
              integer-logarithms -check-bounds +integer-gmp,
-             any.json-spec ==1.3.0.2,
+             any.json-spec ==1.4.0.0,
              json-spec-elm +compile-elm,
              any.mmorph ==1.2.2,
              any.mtl ==2.3.1,
@@ -117,4 +117,4 @@ constraints: any.HUnit ==1.6.2.0,
              vector +boundschecks -internalchecks -unsafechecks -wall,
              any.vector-stream ==0.1.0.1,
              any.witherable ==0.5
-index-state: hackage.haskell.org 2026-06-25T23:00:07Z
+index-state: hackage.haskell.org 2026-07-23T03:55:38Z

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0.0
+
+- Support `JsonDict` from `json-spec` 1.4, generating Elm `Dict`
+  encoders and decoders.
+- Require `json-spec` >= 1.4.0.0.
+
 ## 0.5.0.3
 
 - Refresh dependency freeze and allow `containers` 0.8.

--- a/json-spec-elm.cabal
+++ b/json-spec-elm.cabal
@@ -25,7 +25,7 @@ common dependencies
     , base                 >= 4.19.2.0 && < 4.23
     , containers           >= 0.6.8    && < 0.9
     , elm-syntax           >= 0.3.3.0  && < 0.4
-    , json-spec            >= 1.3.0.0  && < 1.4
+    , json-spec            >= 1.4.0.0  && < 1.5
     , text                 >= 2.1.1    && < 2.2
 
 common warnings

--- a/json-spec-elm.cabal
+++ b/json-spec-elm.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-elm
-version:             0.5.0.3
+version:             0.6.0.0
 synopsis:            Elm code generate for `json-spec`.
 description:         
                      Produce elm types, encoders, and decoders from a

--- a/src/Data/JsonSpec/Elm.hs
+++ b/src/Data/JsonSpec/Elm.hs
@@ -101,28 +101,34 @@ module Data.JsonSpec.Elm (
   Named,
 ) where
 
-
 import Bound (Scope(Scope), Var(B), abstract1, closed, toScope)
-import Control.Monad.Writer (MonadTrans(lift), MonadWriter(tell),
-  Writer, execWriter)
-import Data.JsonSpec (FieldSpec(Optional, Required),
-  Specification(JsonArray, JsonBool, JsonDateTime, JsonEither, JsonInt,
-  JsonLet, JsonNullable, JsonNum, JsonObject, JsonRef, JsonString,
-  JsonTag))
+import Control.Monad.Writer
+  ( MonadTrans(lift), MonadWriter(tell), Writer, execWriter
+  )
+import Data.JsonSpec
+  ( FieldSpec(Optional, Required)
+  , Specification
+    ( JsonArray, JsonBool, JsonDateTime, JsonDict, JsonEither, JsonInt, JsonLet
+    , JsonNullable, JsonNum, JsonObject, JsonRef, JsonString, JsonTag
+    )
+  )
 import Data.Proxy (Proxy(Proxy))
 import Data.Set (Set)
 import Data.String (IsString(fromString))
 import Data.Text (Text)
 import Data.Void (Void, absurd)
-import GHC.TypeLits (ErrorMessage((:$$:), (:<>:)), KnownSymbol, Symbol,
-  TypeError, symbolVal)
+import GHC.TypeLits
+  ( ErrorMessage((:$$:), (:<>:)), KnownSymbol, Symbol, TypeError, symbolVal
+  )
 import Language.Elm.Definition (Definition)
 import Language.Elm.Expression ((|>), Expression, if_)
 import Language.Elm.Name (Constructor, Qualified)
 import Language.Elm.Type (Type)
-import Prelude (Applicative(pure), Bool(False, True), Foldable(foldl,
-  foldr), Functor(fmap), Maybe(Just, Nothing), Monad((>>)),
-  Semigroup((<>)), Show(show), ($), (++), (.), (<$>), Int, error, zip)
+import Prelude
+  ( Applicative(pure), Bool(False, True), Foldable(foldl, foldr), Functor(fmap)
+  , Maybe(Just, Nothing), Monad((>>)), Semigroup((<>)), Show(show), ($), (++)
+  , (.), (<$>), Int, error, zip
+  )
 import qualified Data.Char as Char
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -132,7 +138,6 @@ import qualified Language.Elm.Expression as Expr
 import qualified Language.Elm.Name as Name
 import qualified Language.Elm.Pattern as Pat
 import qualified Language.Elm.Type as Type
-
 
 {-|
   Generate Elm type, encoder, and decoder 'Definition's for all /named/
@@ -356,6 +361,16 @@ instance (HasType spec) => HasType (JsonArray spec) where
   encoderOf = do
     encoder <- encoderOf @spec
     pure $ "Json.Encode.list" `a` encoder
+instance (HasType spec) => HasType (JsonDict spec) where
+  typeOf = do
+    elemType <- typeOf @spec
+    pure $ "Dict.Dict" `ta` "String.String" `ta` elemType
+  decoderOf = do
+    dec <- decoderOf @spec
+    pure $ "Json.Decode.dict" `a` dec
+  encoderOf = do
+    encoder <- encoderOf @spec
+    pure $ "Json.Encode.dict" `a` "Basics.identity" `a` encoder
 instance HasType JsonBool where
   typeOf = pure "Basics.Bool"
   decoderOf = pure "Json.Decode.bool"

--- a/test/test.hs
+++ b/test/test.hs
@@ -6,17 +6,22 @@ module Main (main) where
 
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict (HashMap)
-import Data.JsonSpec (FieldSpec(Optional, Required),
-  Specification(JsonArray, JsonDateTime, JsonEither, JsonInt, JsonLet,
-  JsonNullable, JsonNum, JsonObject, JsonRef, JsonString, JsonTag))
+import Data.JsonSpec
+  ( FieldSpec(Optional, Required)
+  , Specification
+    ( JsonArray, JsonDateTime, JsonDict, JsonEither, JsonInt, JsonLet
+    , JsonNullable, JsonNum, JsonObject, JsonRef, JsonString, JsonTag
+    )
+  )
 import Data.JsonSpec.Elm (Named, elmDefs)
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(Proxy))
 import Data.Text (Text)
 import Language.Elm.Name (Module)
 import Language.Elm.Pretty (modules)
-import Prelude (Bool(True), Functor(fmap), Semigroup((<>)), ($), (.),
-  FilePath, IO, init)
+import Prelude
+  ( Bool(True), Functor(fmap), Semigroup((<>)), ($), (.), FilePath, IO, init
+  )
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import System.Directory (createDirectoryIfMissing)
@@ -27,7 +32,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
-
 
 main :: IO ()
 main =
@@ -228,6 +232,48 @@ main =
         in do
           actual `shouldBe` expected
           compileElm actual
+      it "works with dict values" $
+        let
+          actual :: HashMap Module Text
+          actual =
+            fmap ((<> "\n") . renderStrict . layoutPretty defaultLayoutOptions)
+            . modules
+            . Set.toList
+            $ elmDefs (Proxy @DictSpec)
+
+          expected :: HashMap Module Text
+          expected =
+            HM.singleton
+              ["Api", "Data"]
+              ( Text.unlines
+                  [ "module Api.Data exposing"
+                  , "    ( scoresDecoder"
+                  , "    , scoresEncoder"
+                  , "    , Scores"
+                  , "    )"
+                  , ""
+                  , "import Dict"
+                  , "import Json.Decode"
+                  , "import Json.Encode"
+                  , ""
+                  , ""
+                  , "scoresDecoder : Json.Decode.Decoder Scores"
+                  , "scoresDecoder ="
+                  , "    Json.Decode.dict Json.Decode.int"
+                  , ""
+                  , ""
+                  , "scoresEncoder : Scores -> Json.Encode.Value"
+                  , "scoresEncoder ="
+                  , "    Json.Encode.dict identity Json.Encode.int"
+                  , ""
+                  , ""
+                  , "type alias Scores  ="
+                  , "    Dict.Dict String Int"
+                  ]
+              )
+        in do
+          actual `shouldBe` expected
+          compileElm actual
       it "works with optionality" $
         let
           actual :: HashMap Module Text
@@ -411,6 +457,11 @@ type ExampleSpec =
 type NullableSpec =
   Named "NullableInt"
     (JsonNullable JsonInt)
+
+
+type DictSpec =
+  Named "Scores"
+    (JsonDict JsonInt)
 
 
 writeModule :: (Module, Text) -> IO ()


### PR DESCRIPTION
json-spec 1.4 introduces JsonDict; generate Dict.Dict String types with
matching encoders and decoders. Raise the json-spec dependency bound
accordingly and add a compile test for dict-valued specifications.